### PR TITLE
Fixed incompatibility with stock logger when using blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.swp
+/doc
+/pkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+---
+after_script:
+- rake travis:after -t
+before_script:
+- gem install hoe-travis --no-rdoc --no-ri
+- rake travis:before -t
+language: ruby
+notifications:
+  email:
+  - drbrain@segment7.net
+rvm:
+- 1.8.7
+- 1.9.2
+- 1.9.3
+script: rake travis

--- a/History.txt
+++ b/History.txt
@@ -1,4 +1,4 @@
-== 1.4.1
+== 1.4.1 / 2012-03-22
 
 * Bug fixes
   * Messages for syslog() are no longer cleaned twice.  Pull Request #3 by

--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,9 @@
+== 1.4.1
+
+* Bug fixes
+  * Messages for syslog() are no longer cleaned twice.  Pull Request #3 by
+    Lourens Naudé
+
 == 1.4.0 / 2007-05-08
 
 * Split from rails_analyzer_tools.

--- a/README.txt
+++ b/README.txt
@@ -1,17 +1,56 @@
 = SyslogLogger
 
+Documentation :: http://docs.seattlerb.org/SyslogLogger
+Source        :: https://github.com/seattlerb/sysloglogger
+Bugtracker    :: https://github.com/seattlerb/sysloglogger/issues
+
+== DESCRIPTION
+
 SyslogLogger is a Logger replacement that logs to syslog.  It is almost
-drop-in with a few caveats.
+drop-in with a few differences.
 
-http://seattlerb.rubyforge.org/SyslogLogger
+== FEATURES
 
-http://rubyforge.org/projects/seattlerb
+* Works like Logger
+* Logs to syslog(3) mapping Logger levels to syslog(3) levels
 
-== About
+== SYNOPSIS
 
-See SyslogLogger
+  require 'syslog_logger'
 
-== Install
+  logger = SyslogLogger.new 'your_application_name'
 
-  sudo gem install SyslogLogger
+  logger.info 'did something cool'
+
+== INSTALL
+
+  gem install SyslogLogger
+
+You may need to configure your syslog.conf to place application logs in a
+particular file.  See SyslogLogger for details.
+
+== LICENSE
+
+(The MIT License)
+
+Copyright (c) Eric Hodel
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,6 @@
 
 require 'hoe'
 
-Hoe.plugin :seattlerb
 Hoe.plugin :travis
 Hoe.plugin :git
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require 'hoe'
 
 Hoe.plugin :seattlerb
 Hoe.plugin :travis
+Hoe.plugin :git
 
 Hoe.spec 'SyslogLogger' do
   developer 'Eric Hodel', 'drbrain@segment7.net'

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,8 @@ Hoe.plugin :travis
 Hoe.spec 'SyslogLogger' do
   developer 'Eric Hodel', 'drbrain@segment7.net'
 
-  self.rubyforge_name = 'seattlerb'
+  rdoc_locations <<
+    'docs.seattlerb.org:/data/www/docs.seattlerb.org/SyslogLogger'
 end
 
 # vim: syntax=Ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,9 @@
 # -*- ruby -*-
 
 require 'hoe'
-require './lib/syslog_logger.rb'
 
 Hoe.plugin :seattlerb
+Hoe.plugin :travis
 
 Hoe.spec 'SyslogLogger' do
   developer 'Eric Hodel', 'drbrain@segment7.net'

--- a/lib/syslog_logger.rb
+++ b/lib/syslog_logger.rb
@@ -77,10 +77,15 @@ class SyslogLogger
   ##
   # The version of SyslogLogger you are using.
 
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 
   ##
   # Maps Logger warning types to syslog(3) warning types.
+  #
+  # Messages from ruby applications are not considered as critical as messages
+  # from other processes using syslog(3), so most messages are reduced by one
+  # level.  For example, a fatal message for ruby's Logger is considered an
+  # error for syslog(3).
 
   LOGGER_MAP = {
     :unknown => :alert,
@@ -125,6 +130,42 @@ class SyslogLogger
       end
     EOM
   end
+
+  ##
+  # :method: unknown
+  #
+  # Logs a +message+ at the unknown (syslog alert) log level, or logs the
+  # message returned from the block.
+
+  ##
+  # :method: fatal
+  #
+  # Logs a +message+ at the fatal (syslog err) log level, or logs the message
+  # returned from the block.
+
+  ##
+  # :method: error
+  #
+  # Logs a +message+ at the error (syslog warning) log level, or logs the
+  # message returned from the block.
+
+  ##
+  # :method: warn
+  #
+  # Logs a +message+ at the warn (syslog notice) log level, or logs the
+  # message returned from the block.
+
+  ##
+  # :method: info
+  #
+  # Logs a +message+ at the info (syslog info) log level, or logs the message
+  # returned from the block.
+
+  ##
+  # :method: debug
+  #
+  # Logs a +message+ at the debug (syslog debug) log level, or logs the
+  # message returned from the block.
 
   LOGGER_MAP.each_key do |level|
     make_methods level

--- a/lib/syslog_logger.rb
+++ b/lib/syslog_logger.rb
@@ -155,8 +155,7 @@ class SyslogLogger
   def add(severity, message = nil, progname = nil, &block)
     severity ||= Logger::UNKNOWN
     return true if severity < @level
-    message = clean(message || block.call)
-    SYSLOG.send LEVEL_LOGGER_MAP[severity], clean(message)
+    SYSLOG.send LEVEL_LOGGER_MAP[severity], clean(message || block.call)
     return true
   end
 

--- a/test/test_syslog_logger.rb
+++ b/test/test_syslog_logger.rb
@@ -50,12 +50,12 @@ class TestLogger < Test::Unit::TestCase
     attr_reader :line, :label, :datetime, :pid, :severity, :progname, :msg
     def initialize(line)
       @line = line
-      /\A(\w+), \[([^#]*)#(\d+)\]\s+(\w+) -- (\w*): ([\x0-\xff]*)/ =~ @line
+      /\A(\w+), \[([^#]*)#(\d+)\]\s+(\w+) -- (\w*): ([\x0-\xff]*)\n\z/ =~ @line
       @label, @datetime, @pid, @severity, @progname, @msg = $1, $2, $3, $4, $5, $6
     end
   end
 
-  def log_add(severity, msg, progname = nil, &block)
+  def log_add(severity, msg = nil, progname = nil, &block)
     log(:add, severity, msg, progname, &block)
   end
 
@@ -443,6 +443,18 @@ class TestLogger < Test::Unit::TestCase
     assert_equal false, @logger.debug?
   end
 
+  def test_blocks
+    message = 'A message logged from within a block'
+    msg = log(:debug) { message }
+    assert_equal LEVEL_LABEL_MAP[Logger::DEBUG], msg.severity
+    assert_equal message, msg.msg
+
+    # Test compatibility with logger.debug('progname') { 'a message' }
+    msg = log(:debug, 'progname') { message }
+    assert_equal LEVEL_LABEL_MAP[Logger::DEBUG], msg.severity
+    assert_equal message, msg.msg
+  end
+
 end
 
 class TestSyslogLogger < TestLogger
@@ -464,7 +476,7 @@ class TestSyslogLogger < TestLogger
     end
   end
 
-  def log_add(severity, msg, progname = nil, &block)
+  def log_add(severity, msg = nil, progname = nil, &block)
     log(:add, severity, msg, progname, &block)
   end
 


### PR DESCRIPTION
Specifically, `logger.debug('progname') { "A message inside a block" }` behaves differently in SyslogLogger and stock logger. In stock logger, "progname" is taken as the progname, and the block will be eval'ed and the result will be used as the log message. In SyslogLogger, "progname" is taken as the message and the block is never evaluated.
